### PR TITLE
Fix sorting for books like 1 John

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ def calculate_category(filename_root, books):
 
 def calculate_sort_field(path_parts, filename_root, books):
     """ Calculate where this item should be sorted.  Returns a string that
-        can be used to naturally sort the files. 
+        can be used to naturally sort the files.
 
         books is a dictionary (defined in languages.json) where the key is
         the book name, and has a field "num" which can be used to sort in
@@ -179,10 +179,7 @@ def calculate_sort_field(path_parts, filename_root, books):
     # is to ensure that books with shorter similar names don't accidentally
     # get matched before longer ones, e.g. "1 John" being matches as
     # "John".
-    book_names_by_length = sorted(
-        [book for book in books], 
-        key=lambda book: len(book),
-        reverse=True)
+    book_names_by_length = sorted(list(books), key=len, reverse=True)
 
     # If the filename contains a book of the Bible, sort in canonical order
     book_number = "00-"

--- a/main.py
+++ b/main.py
@@ -175,9 +175,18 @@ def calculate_sort_field(path_parts, filename_root, books):
         canonical order.
         """
 
+    # Create index of book names in order from longest to shortest.  This
+    # is to ensure that books with shorter similar names don't accidentally
+    # get matched before longer ones, e.g. "1 John" being matches as
+    # "John".
+    book_names_by_length = sorted(
+        [book for book in books], 
+        key=lambda book: len(book),
+        reverse=True)
+
     # If the filename contains a book of the Bible, sort in canonical order
     book_number = "00-"
-    for book in books:
+    for book in book_names_by_length:
         if book in filename_root:
             book_number = str(books[book]["num"]).zfill(2) + "-"
             break

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@
     imported into analyze-catalog for the BIEL website. """
 
 import json
-import logging
 import operator
 import os
 import pathlib

--- a/main.py
+++ b/main.py
@@ -184,7 +184,7 @@ def calculate_sort_field(path_parts, filename_root, books):
 
     # Sort shallower items before deeper ones, then by directory
     sort = str(len(path_parts)) + "-" + \
-           "/".join(path_parts[2:-1] + (book_number + filename_root,))
+            "/".join(path_parts[2:] + (book_number + filename_root,))
 
     return sort
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@
     imported into analyze-catalog for the BIEL website. """
 
 import json
+import logging
 import operator
 import os
 import pathlib
@@ -177,7 +178,7 @@ def calculate_sort_field(path_parts, filename_root, books):
 
     # Create index of book names in order from longest to shortest.  This
     # is to ensure that books with shorter similar names don't accidentally
-    # get matched before longer ones, e.g. "1 John" being matches as
+    # get matched before longer ones, e.g. "1 John" being matched as
     # "John".
     book_names_by_length = sorted(list(books), key=len, reverse=True)
 
@@ -190,7 +191,7 @@ def calculate_sort_field(path_parts, filename_root, books):
 
     # Sort shallower items before deeper ones, then by directory
     sort = str(len(path_parts)) + "-" + \
-            "/".join(path_parts[2:] + (book_number + filename_root,))
+            "/".join(path_parts[2:-1] + (book_number + filename_root,))
 
     return sort
 

--- a/test_main.py
+++ b/test_main.py
@@ -108,9 +108,9 @@ class TestMain(unittest.TestCase):
 
     def test_calculate_sort_field_john(self):
         """ Test that books sort in the correct order """
-        EN_INDEX = 0
+        en_index = 0
         languages = main.load_json("languages.json")
-        books = languages[EN_INDEX]["books"]
+        books = languages[en_index]["books"]
         self.assertEqual("4-dir1/dir2/44-John Guide", main.calculate_sort_field(("en",
             "review-guide", "dir1", "dir2"), "John Guide", books))
         self.assertEqual("4-dir1/dir2/63-1 John Guide", main.calculate_sort_field(("en",

--- a/test_main.py
+++ b/test_main.py
@@ -55,9 +55,20 @@ class TestMain(unittest.TestCase):
                           "zipContent": "",
                           "quality": None,
                           "chapters": []}]},
-                    {"name": "Guide for Genesis",
+                    {"name": "Guide for BrokenBook",
                      "code": "",
                      "sort": 2,
+                     "category": "topics",
+                     "links": [
+                         {"url":
+                          "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%20BrokenBook.docx",
+                          "format": "docx",
+                          "zipContent": "",
+                          "quality": None,
+                          "chapters": []}]},
+                    {"name": "Guide for Genesis",
+                     "code": "",
+                     "sort": 3,
                      "category": "bible-ot",
                      "links": [
                          {"url":
@@ -74,7 +85,7 @@ class TestMain(unittest.TestCase):
                           "chapters": []}]},
                     {"name": "Guide for Matthew",
                      "code": "",
-                     "sort": 3,
+                     "sort": 4,
                      "category": "bible-nt",
                      "links": [
                          {"url":
@@ -89,17 +100,6 @@ class TestMain(unittest.TestCase):
                           "zipContent": "",
                           "quality": None,
                           "chapters": []}]},
-                    {"name": "Guide for BrokenBook",
-                     "code": "",
-                     "sort": 4,
-                     "category": "topics",
-                     "links": [
-                         {"url":
-                          "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%20BrokenBook.docx",
-                          "format": "docx",
-                          "zipContent": "",
-                          "quality": None,
-                          "chapters": []}]},
                     ]}]}]
         files = main.filter_files_from_tree(tree, "en", "review-guide", extensions, books)
         actual = main.create_biel_data_from_tree(
@@ -111,7 +111,7 @@ class TestMain(unittest.TestCase):
         EN_INDEX = 0
         languages = main.load_json("languages.json")
         books = languages[EN_INDEX]["books"]
-        self.assertEqual("44-John Guide", main.calculate_sort_field(("en",
+        self.assertEqual("4-dir1/dir2/44-John Guide", main.calculate_sort_field(("en",
             "review-guide", "dir1", "dir2"), "John Guide", books))
 
 

--- a/test_main.py
+++ b/test_main.py
@@ -113,8 +113,12 @@ class TestMain(unittest.TestCase):
         books = languages[EN_INDEX]["books"]
         self.assertEqual("4-dir1/dir2/44-John Guide", main.calculate_sort_field(("en",
             "review-guide", "dir1", "dir2"), "John Guide", books))
-        self.assertEqual("4-dir1/dir2/50-1 John Guide", main.calculate_sort_field(("en",
+        self.assertEqual("4-dir1/dir2/63-1 John Guide", main.calculate_sort_field(("en",
             "review-guide", "dir1", "dir2"), "1 John Guide", books))
+        self.assertEqual("4-dir1/dir2/64-2 John Guide", main.calculate_sort_field(("en",
+            "review-guide", "dir1", "dir2"), "2 John Guide", books))
+        self.assertEqual("4-dir1/dir2/65-3 John Guide", main.calculate_sort_field(("en",
+            "review-guide", "dir1", "dir2"), "3 John Guide", books))
 
 
 

--- a/test_main.py
+++ b/test_main.py
@@ -113,6 +113,8 @@ class TestMain(unittest.TestCase):
         books = languages[EN_INDEX]["books"]
         self.assertEqual("4-dir1/dir2/44-John Guide", main.calculate_sort_field(("en",
             "review-guide", "dir1", "dir2"), "John Guide", books))
+        self.assertEqual("4-dir1/dir2/50-1 John Guide", main.calculate_sort_field(("en",
+            "review-guide", "dir1", "dir2"), "1 John Guide", books))
 
 
 

--- a/test_main.py
+++ b/test_main.py
@@ -106,5 +106,15 @@ class TestMain(unittest.TestCase):
             files, "wa-biel", "biel-files", "master", "en", "Reviewers' Guide")
         self.assertEqual(expected, actual)
 
+    def test_calculate_sort_field_john(self):
+        """ Test that books sort in the correct order """
+        EN_INDEX = 0
+        languages = main.load_json("languages.json")
+        books = languages[EN_INDEX]["books"]
+        self.assertEqual("44-John Guide", main.calculate_sort_field(("en",
+            "review-guide", "dir1", "dir2"), "John Guide", books))
+
+
+
 if __name__ == "__main__": # pragma: no cover
     unittest.main()

--- a/test_main.py
+++ b/test_main.py
@@ -15,6 +15,10 @@ class TestMain(unittest.TestCase):
         # pylint: disable=line-too-long
         tree = Mock(tree=[
             Mock(path="en/not-in-review-guide/dir1/dir2/Example Guide.pdf"),
+            Mock(path="en/review-guide/dir1/dir2/Guide for 1 John.pdf"),
+            Mock(path="en/review-guide/dir1/dir2/Guide for 1 John.docx"),
+            Mock(path="en/review-guide/dir1/dir2/Guide for Numbers.docx"),
+            Mock(path="en/review-guide/dir1/dir2/Guide for Numbers.pdf"),
             Mock(path="en/review-guide/dir1/dir2/Guide for Matthew.docx"),
             Mock(path="en/review-guide/dir1/dir2/Guide for Matthew.pdf"),
             Mock(path="en/review-guide/dir1/dir2/Guide for Genesis.docx"),
@@ -27,7 +31,9 @@ class TestMain(unittest.TestCase):
         extensions = ["pdf", "docx", "zip"]
         books = {
             "Genesis": {"num": 1, "anth": "ot"},
+            "Numbers": {"num": 4, "anth": "ot"},
             "Matthew": {"num": 41, "anth": "nt"},
+            "1 John": {"num": 63, "anth": "nt"},
             "BrokenBook": {"num": 68, "anth": "broken"}}
         expected = [{
             "code": "en",
@@ -55,20 +61,9 @@ class TestMain(unittest.TestCase):
                           "zipContent": "",
                           "quality": None,
                           "chapters": []}]},
-                    {"name": "Guide for BrokenBook",
-                     "code": "",
-                     "sort": 2,
-                     "category": "topics",
-                     "links": [
-                         {"url":
-                          "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%20BrokenBook.docx",
-                          "format": "docx",
-                          "zipContent": "",
-                          "quality": None,
-                          "chapters": []}]},
                     {"name": "Guide for Genesis",
                      "code": "",
-                     "sort": 3,
+                     "sort": 2,
                      "category": "bible-ot",
                      "links": [
                          {"url":
@@ -79,6 +74,23 @@ class TestMain(unittest.TestCase):
                           "chapters": []},
                          {"url":
                           "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%20Genesis.pdf",
+                          "format": "pdf",
+                          "zipContent": "",
+                          "quality": None,
+                          "chapters": []}]},
+                    {"name": "Guide for Numbers",
+                     "code": "",
+                     "sort": 3,
+                     "category": "bible-ot",
+                     "links": [
+                         {"url":
+                          "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%20Numbers.docx",
+                          "format": "docx",
+                          "zipContent": "",
+                          "quality": None,
+                          "chapters": []},
+                         {"url":
+                          "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%20Numbers.pdf",
                           "format": "pdf",
                           "zipContent": "",
                           "quality": None,
@@ -100,6 +112,34 @@ class TestMain(unittest.TestCase):
                           "zipContent": "",
                           "quality": None,
                           "chapters": []}]},
+                    {"name": "Guide for 1 John",
+                     "code": "",
+                     "sort": 5,
+                     "category": "bible-nt",
+                     "links": [
+                         {"url":
+                          "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%201%20John.docx",
+                          "format": "docx",
+                          "zipContent": "",
+                          "quality": None,
+                          "chapters": []},
+                         {"url":
+                          "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%201%20John.pdf",
+                          "format": "pdf",
+                          "zipContent": "",
+                          "quality": None,
+                          "chapters": []}]},
+                    {"name": "Guide for BrokenBook",
+                     "code": "",
+                     "sort": 6,
+                     "category": "topics",
+                     "links": [
+                         {"url":
+                          "https://github.com/wa-biel/biel-files/raw/master/en/review-guide/dir1/dir2/Guide%20for%20BrokenBook.docx",
+                          "format": "docx",
+                          "zipContent": "",
+                          "quality": None,
+                          "chapters": []}]},
                     ]}]}]
         files = main.filter_files_from_tree(tree, "en", "review-guide", extensions, books)
         actual = main.create_biel_data_from_tree(
@@ -111,14 +151,14 @@ class TestMain(unittest.TestCase):
         en_index = 0
         languages = main.load_json("languages.json")
         books = languages[en_index]["books"]
-        self.assertEqual("4-dir1/dir2/44-John Guide", main.calculate_sort_field(("en",
-            "review-guide", "dir1", "dir2"), "John Guide", books))
-        self.assertEqual("4-dir1/dir2/63-1 John Guide", main.calculate_sort_field(("en",
-            "review-guide", "dir1", "dir2"), "1 John Guide", books))
-        self.assertEqual("4-dir1/dir2/64-2 John Guide", main.calculate_sort_field(("en",
-            "review-guide", "dir1", "dir2"), "2 John Guide", books))
-        self.assertEqual("4-dir1/dir2/65-3 John Guide", main.calculate_sort_field(("en",
-            "review-guide", "dir1", "dir2"), "3 John Guide", books))
+        self.assertEqual("5-dir1/dir2/44-John Guide", main.calculate_sort_field(("en",
+            "review-guide", "dir1", "dir2", "John Guide.pdf"), "John Guide", books))
+        self.assertEqual("5-dir1/dir2/63-1 John Guide", main.calculate_sort_field(("en",
+            "review-guide", "dir1", "dir2", "1 John Guide.pdf"), "1 John Guide", books))
+        self.assertEqual("5-dir1/dir2/64-2 John Guide", main.calculate_sort_field(("en",
+            "review-guide", "dir1", "dir2", "2 John Guide.docx"), "2 John Guide", books))
+        self.assertEqual("5-dir1/dir2/65-3 John Guide", main.calculate_sort_field(("en",
+            "review-guide", "dir1", "dir2", "3 John Guide.docx"), "3 John Guide", books))
 
 
 


### PR DESCRIPTION
This change fixes a bug where books whose names contain another book of the bible (e.g. "1 John" containing "John") can get identified as the wrong book and get sorted to the wrong spot in the list.

To fix this, when looking for the book name in a file name, we search from the longest book name to the shortest, to ensure that we don't accidentally associate a file with the wrong book.

I also added some tests to confirm the fix.